### PR TITLE
Fix Euler rotation order to use ZYX (intrinsic) instead of default XYZ (intrinsic)

### DIFF
--- a/src/adapters/MJCFAdapter.js
+++ b/src/adapters/MJCFAdapter.js
@@ -1588,11 +1588,12 @@ export class MJCFAdapter {
                         mesh.rotation.set(
                             fromtoRpy[0] + visual.origin.rpy[0],
                             fromtoRpy[1] + visual.origin.rpy[1],
-                            fromtoRpy[2] + visual.origin.rpy[2]
+                            fromtoRpy[2] + visual.origin.rpy[2],
+                            'ZYX'
                         );
                     } else {
-                        mesh.position.set(...visual.origin.xyz);
-                        mesh.rotation.set(...visual.origin.rpy);
+                        mesh.position.set(...visual.origin.xyz, 'ZYX');
+                        mesh.rotation.set(...visual.origin.rpy, 'ZYX');
                     }
                     mesh.name = visual.name || 'visual';
 
@@ -1716,11 +1717,12 @@ export class MJCFAdapter {
                         mesh.rotation.set(
                             fromtoRpy[0] + collision.origin.rpy[0],
                             fromtoRpy[1] + collision.origin.rpy[1],
-                            fromtoRpy[2] + collision.origin.rpy[2]
+                            fromtoRpy[2] + collision.origin.rpy[2],
+                            'ZYX'
                         );
                     } else {
                         mesh.position.set(...collision.origin.xyz);
-                        mesh.rotation.set(...collision.origin.rpy);
+                        mesh.rotation.set(...collision.origin.rpy,'ZYX');
                     }
                     mesh.name = collision.name || 'collision';
 
@@ -1798,7 +1800,7 @@ export class MJCFAdapter {
                     bodyOrigin.xyz[1] + joint.origin.xyz[1],
                     bodyOrigin.xyz[2] + joint.origin.xyz[2]
                 );
-                jointGroup.rotation.set(...bodyOrigin.rpy);
+                jointGroup.rotation.set(...bodyOrigin.rpy, 'ZYX');
 
                 // Recursively build child link
                 buildHierarchy(childLinkName, jointGroup);
@@ -1825,7 +1827,7 @@ export class MJCFAdapter {
                         // Create fixed connection group
                         const fixedGroup = new THREE.Group();
                         fixedGroup.position.set(...childBodyOrigin.xyz);
-                        fixedGroup.rotation.set(...childBodyOrigin.rpy);
+                        fixedGroup.rotation.set(...childBodyOrigin.rpy, 'ZYX');
 
                         // Recursively build child body and add to fixed group
                         buildHierarchy(childName, fixedGroup);
@@ -1844,7 +1846,7 @@ export class MJCFAdapter {
                 const rootLinkGroup = linkObjects.get(rootName);
                 if (rootLink.userData.bodyOrigin) {
                     rootLinkGroup.position.set(...rootLink.userData.bodyOrigin.xyz);
-                    rootLinkGroup.rotation.set(...rootLink.userData.bodyOrigin.rpy);
+                    rootLinkGroup.rotation.set(...rootLink.userData.bodyOrigin.rpy, 'ZYX');
                 }
                 buildHierarchy(rootName, rootGroup);
             });
@@ -1855,7 +1857,7 @@ export class MJCFAdapter {
             const firstLinkGroup = linkObjects.get(firstLink);
             if (firstLinkObj.userData.bodyOrigin) {
                 firstLinkGroup.position.set(...firstLinkObj.userData.bodyOrigin.xyz);
-                firstLinkGroup.rotation.set(...firstLinkObj.userData.bodyOrigin.rpy);
+                firstLinkGroup.rotation.set(...firstLinkObj.userData.bodyOrigin.rpy, 'ZYX');
             }
             buildHierarchy(firstLink, rootGroup);
         }

--- a/src/adapters/USDAdapter.js
+++ b/src/adapters/USDAdapter.js
@@ -337,7 +337,7 @@ export class USDAdapter {
                 const mesh = this.createGeometryMesh(visual.geometry);
                 if (mesh) {
                     mesh.position.set(...visual.origin.xyz);
-                    mesh.rotation.set(...visual.origin.rpy);
+                    mesh.rotation.set(...visual.origin.rpy, 'ZYX');
                     mesh.name = visual.name;
                     linkGroup.add(mesh);
                     visual.threeObject = mesh;

--- a/src/renderer/InertialVisualization.js
+++ b/src/renderer/InertialVisualization.js
@@ -317,9 +317,9 @@ export class InertialVisualization {
         } else if (inertial.origin && inertial.origin.rpy) {
             // For URDF with RPY (though this is usually just for COM position, not inertia orientation)
             const rpy = inertial.origin.rpy;
-            inertiaBox.rotation.set(rpy[0], rpy[1], rpy[2], 'XYZ');
+            inertiaBox.rotation.set(rpy[0], rpy[1], rpy[2], 'ZYX');
         } else {
-            inertiaBox.rotation.set(0, 0, 0);
+            inertiaBox.rotation.set(0, 0, 0, 'ZYX');
         }
 
         inertiaBox.visible = this.showInertia;


### PR DESCRIPTION
## Summary
- Fix Euler rotation order to use ZYX (intrinsic) instead of default XYZ to correctly match URDF/MJCF euler angle conventions
- Update rotation settings in MJCFAdapter.js, USDAdapter.js, and InertialVisualization.js


## Problem
Three.js Object3D.rotation.set() uses XYZ euler order [by default](https://threejs.org/docs/?q=euler#Euler..DEFAULT_ORDER), which differs from the [euler order used in URDF](https://urdfpy.readthedocs.io/en/latest/generated/urdfpy.rpy_to_matrix.html) formats, and the self-built `quaternionToEuler` function https://github.com/petertheprocess/robot_viewer/blob/53d3103c2a818d20358fc2bec423303147212fa0/src/adapters/MJCFAdapter.js#L999-L1024. 

This caused incorrect orientation of visual/collision meshes and inertial visualizations.




## Solution
Explicitly specify 'ZYX' euler order when setting rotations to ensure consistency with robot model format conventions.


## Result
Using [agilex_piper](https://github.com/google-deepmind/mujoco_menagerie/tree/main/agilex_piper) mjcf from mujoco_menagerie as demonstration


<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/ab0be1f0-4f68-432b-9f8b-4cdd01dbaf53" alt="image 1" width="400"/>
<br />
      <strong>Before (Default XYZ)</strong> </td>
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/0f889d53-a211-4e85-9697-eabeeba64bef" alt="image 2" width="400"/>
<br />
      <strong>After (ZYX)</strong> </td>
    </td>
  </tr>
</table>


## TODO for improvement
- [ ] parse eulerseq tag for mujoco mjcf, for ref: https://mujoco.readthedocs.io/en/stable/XMLreference.html#compiler-eulerseq
- [ ] Refactor internal rotation representation in `UnifiedRobotModel.js`: Switch from Euler angles (origin.rpy) to Quaternions during the model load stage. Storing rotations as Quaternions avoids ambiguity in the rendering pipeline and eliminates the risk of missing the explicit 'ZYX' order in Three.js `rotation.set()` calls.

## More ref for euler order
- [Extrinsic & intrinsic rotation: Do I multiply from right or left?](https://dominicplein.medium.com/extrinsic-intrinsic-rotation-do-i-multiply-from-right-or-left-357c38c1abfd)
- [Euler angles wikipedia](https://en.wikipedia.org/wiki/Euler_angles)