### PR TITLE
feat: add YAML-based joint pose import/export with live joint sync

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,65 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: pnpm
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build project
+        run: pnpm run build
+
+      - name: Disable Jekyll processing
+        run: touch dist/.nojekyll
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,7 @@ jobs:
           node-version: '18'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9
+        uses: pnpm/action-setup@v4
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -56,4 +54,3 @@ jobs:
           tag_name: ${{ github.event.release.tag_name }}
           files: robot-viewer-${{ github.event.release.tag_name }}.zip
           overwrite: true
-

--- a/index.html
+++ b/index.html
@@ -1945,6 +1945,150 @@
             border-bottom-color: rgba(0, 0, 0, 0.08);
         }
 
+        .joint-pose-config {
+            margin-bottom: 10px;
+            padding: 10px;
+            background: rgba(255, 255, 255, 0.04);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 14px;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        [data-theme="light"] .joint-pose-config {
+            background: rgba(0, 0, 0, 0.03);
+            border-color: rgba(0, 0, 0, 0.08);
+        }
+
+        .joint-pose-title {
+            font-size: 12px;
+            font-weight: 600;
+            color: var(--text-primary);
+        }
+
+        .joint-pose-field {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .joint-pose-label {
+            font-size: 11px;
+            font-weight: 600;
+            color: var(--text-secondary);
+        }
+
+        .joint-pose-textarea {
+            width: 100%;
+            min-height: 86px;
+            padding: 10px 12px;
+            resize: vertical;
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            border-radius: 10px;
+            color: var(--text-primary);
+            font-size: 12px;
+            line-height: 1.45;
+            font-family: 'SF Mono', Monaco, monospace;
+            transition: all 0.2s;
+        }
+
+        .joint-pose-textarea:hover {
+            background: rgba(255, 255, 255, 0.05);
+            border-color: rgba(255, 255, 255, 0.18);
+        }
+
+        .joint-pose-textarea:focus {
+            outline: none;
+            border-color: var(--accent);
+            background: rgba(255, 255, 255, 0.06);
+        }
+
+        .joint-pose-textarea::placeholder {
+            color: var(--text-tertiary);
+        }
+
+        [data-theme="light"] .joint-pose-textarea {
+            background: rgba(0, 0, 0, 0.025);
+            border-color: rgba(0, 0, 0, 0.1);
+        }
+
+        [data-theme="light"] .joint-pose-textarea:hover {
+            background: rgba(0, 0, 0, 0.04);
+            border-color: rgba(0, 0, 0, 0.14);
+        }
+
+        [data-theme="light"] .joint-pose-textarea:focus {
+            background: rgba(0, 0, 0, 0.045);
+        }
+
+        .joint-pose-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+
+        .joint-pose-button {
+            padding: 6px 12px;
+            background: transparent;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            border-radius: 10px;
+            color: var(--text-secondary);
+            font-size: 11px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .joint-pose-button:hover {
+            background: rgba(255, 255, 255, 0.08);
+            color: var(--text-primary);
+        }
+
+        .joint-pose-button.primary {
+            background: var(--accent);
+            border-color: var(--accent);
+            color: white;
+            box-shadow: 0 1px 4px rgba(10, 132, 255, 0.3);
+        }
+
+        .joint-pose-button.primary:hover {
+            background: var(--accent-hover);
+            border-color: var(--accent-hover);
+        }
+
+        [data-theme="light"] .joint-pose-button {
+            border-color: rgba(0, 0, 0, 0.1);
+        }
+
+        [data-theme="light"] .joint-pose-button:hover {
+            background: rgba(0, 0, 0, 0.05);
+        }
+
+        .joint-pose-status {
+            min-height: 16px;
+            font-size: 11px;
+            line-height: 1.4;
+            color: var(--text-tertiary);
+        }
+
+        .joint-pose-status.success {
+            color: #4ade80;
+        }
+
+        .joint-pose-status.error {
+            color: #ff6b6b;
+        }
+
+        .joint-pose-status.warning {
+            color: #fbbf24;
+        }
+
+        .joint-pose-status.info {
+            color: #4a9eff;
+        }
+
         .joint-control {
             margin-bottom: 3px;
             padding: 5px 8px;

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "mujoco-js": "^0.0.7",
     "three": "^0.163.0",
     "urdf-loader": "^0.12.5",
-    "xacro-parser": "^0.3.11"
+    "xacro-parser": "^0.3.11",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "terser": "^5.26.0",
     "vite": "^4.5.0"
   }
 }
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       xacro-parser:
         specifier: ^0.3.11
         version: 0.3.11
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
     devDependencies:
       terser:
         specifier: ^5.26.0
@@ -590,8 +593,8 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
-  yaml@2.8.2:
-    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -1111,12 +1114,12 @@ snapshots:
   xacro-parser@0.3.11:
     dependencies:
       expr-eval-fork: 3.0.1
-      yaml: 2.8.2
+      yaml: 2.8.3
       yargs: 17.7.2
 
   y18n@5.0.8: {}
 
-  yaml@2.8.2: {}
+  yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
 

--- a/src/main.js
+++ b/src/main.js
@@ -145,6 +145,12 @@ class App {
             // Initialize joint controls UI
             this.jointControlsUI = new JointControlsUI(this.sceneManager);
 
+            this.sceneManager.on('jointValueChanged', (model) => {
+                if (this.jointControlsUI && this.currentModel === model) {
+                    this.jointControlsUI.handleExternalJointValueChange(model);
+                }
+            });
+
             // Initialize model graph view
             this.modelGraphView = new ModelGraphView(this.sceneManager);
 

--- a/src/renderer/SceneManager.js
+++ b/src/renderer/SceneManager.js
@@ -585,22 +585,7 @@ export class SceneManager {
             // Apply parallel mechanism constraints
             this.constraintManager.applyConstraints(model, joint);
 
-            // Update corresponding slider (if exists)
-            const slider = document.querySelector(`input[data-joint="${joint.name}"]`);
-            if (slider) {
-                slider.value = angle;
-
-                // Update input box
-                const valueInput = document.querySelector(`input[data-joint-input="${joint.name}"]`);
-                if (valueInput) {
-                    const angleUnit = document.querySelector('#unit-deg.active') ? 'deg' : 'rad';
-                    if (angleUnit === 'deg') {
-                        valueInput.value = (angle * 180 / Math.PI).toFixed(2);
-                    } else {
-                        valueInput.value = angle.toFixed(2);
-                    }
-                }
-            }
+            this.emit('jointValueChanged', model, joint.name, angle);
 
             // Only render during drag, no complex calculations
             this.redraw();

--- a/src/ui/JointControlsUI.js
+++ b/src/ui/JointControlsUI.js
@@ -1,7 +1,8 @@
 /**
  * JointControlsUI - Joint control UI module
- * Responsible for creating and managing joint control sliders and input fields
+ * Responsible for creating and managing joint control sliders and pose presets
  */
+import YAML, { isMap, isSeq } from 'yaml';
 import { ModelLoaderFactory } from '../loaders/ModelLoaderFactory.js';
 import { XMLUpdater } from '../utils/XMLUpdater.js';
 
@@ -9,9 +10,22 @@ export class JointControlsUI {
     constructor(sceneManager) {
         this.sceneManager = sceneManager;
         this.angleUnit = 'rad';
-        this.initialJointValues = new Map(); // Save initial joint positions when model loads
-        this.codeEditorManager = null; // Code editor manager reference
-        this.isUpdatingFromEditor = false; // Flag to prevent circular updates
+        this.initialJointValues = new Map();
+        this.initialValueModel = null;
+        this.codeEditorManager = null;
+        this.isUpdatingFromEditor = false;
+
+        this.jointControlElements = new Map();
+
+        this.poseGroupText = '';
+        this.poseValuesText = '';
+        this.poseStatus = null;
+        this.activePoseConfig = null;
+        this.activePoseModel = null;
+
+        this.poseGroupsTextarea = null;
+        this.poseValuesTextarea = null;
+        this.poseStatusElement = null;
     }
 
     /**
@@ -25,12 +39,7 @@ export class JointControlsUI {
      * Update XML content in editor (URDF format only)
      */
     updateEditorXML(jointName, limits) {
-        // If updating from editor, skip
-        if (this.isUpdatingFromEditor) {
-            return;
-        }
-
-        if (!this.codeEditorManager) {
+        if (this.isUpdatingFromEditor || !this.codeEditorManager) {
             return;
         }
 
@@ -39,47 +48,37 @@ export class JointControlsUI {
             return;
         }
 
-        // Get current editor content
         const currentContent = editor.getValue();
         if (!currentContent || currentContent.trim().length === 0) {
             return;
         }
 
-        // Check if URDF format (contains <robot> tag)
         if (!currentContent.includes('<robot')) {
             return;
         }
 
-        // Set flag to prevent circular updates
         this.isUpdatingFromEditor = true;
 
         try {
-            // Use XMLUpdater to update XML
             const updatedXML = XMLUpdater.updateURDFJointLimits(currentContent, jointName, limits);
 
-            // If content changed, update editor
             if (updatedXML !== currentContent) {
-                // Save cursor position
                 const cursorPos = editor.view.state.selection.main.head;
-
-                // Update content
                 editor.setValue(updatedXML);
 
-                // Restore cursor position (if possible)
                 try {
                     const maxPos = editor.view.state.doc.length;
                     const newPos = Math.min(cursorPos, maxPos);
                     editor.view.dispatch({
                         selection: { anchor: newPos, head: newPos }
                     });
-                } catch (e) {
-                    // Ignore cursor restoration errors
+                } catch (error) {
+                    // Ignore cursor restoration errors.
                 }
             }
         } catch (error) {
             console.error('Failed to update editor XML:', error);
         } finally {
-            // Delay resetting flag to ensure editor onChange doesn't immediately trigger update
             setTimeout(() => {
                 this.isUpdatingFromEditor = false;
             }, 100);
@@ -94,6 +93,10 @@ export class JointControlsUI {
         if (!container) return;
 
         container.innerHTML = '';
+        this.jointControlElements.clear();
+        this.poseGroupsTextarea = null;
+        this.poseValuesTextarea = null;
+        this.poseStatusElement = null;
 
         if (!model || !model.joints || model.joints.size === 0) {
             const emptyState = document.createElement('div');
@@ -118,23 +121,133 @@ export class JointControlsUI {
             return;
         }
 
-        // Save initial joint values when model loads
-        this.initialJointValues.clear();
-        model.joints.forEach((joint, name) => {
-            if (joint.type !== 'fixed') {
-                const limits = joint.limits || {};
-                const lower = limits.lower !== undefined ? limits.lower : -Math.PI;
-                const upper = limits.upper !== undefined ? limits.upper : Math.PI;
-                const initialValue = joint.currentValue !== undefined ? joint.currentValue : (lower + upper) / 2;
-                this.initialJointValues.set(name, initialValue);
-            }
-        });
+        if (this.activePoseConfig && this.activePoseModel && this.activePoseModel !== model) {
+            this.activePoseConfig = null;
+            this.activePoseModel = null;
 
-        model.joints.forEach((joint, name) => {
+            if (this.poseGroupText.trim() || this.poseValuesText.trim()) {
+                this.setPoseStatus('info', 'jointPoseReapplyRequired');
+            }
+        }
+
+        if (this.initialValueModel !== model) {
+            this.initialJointValues.clear();
+            model.joints.forEach((joint, name) => {
+                if (joint.type !== 'fixed') {
+                    const limits = joint.limits || {};
+                    const lower = limits.lower !== undefined ? limits.lower : -Math.PI;
+                    const upper = limits.upper !== undefined ? limits.upper : Math.PI;
+                    const initialValue = joint.currentValue !== undefined ? joint.currentValue : (lower + upper) / 2;
+                    this.initialJointValues.set(name, initialValue);
+                }
+            });
+            this.initialValueModel = model;
+        }
+
+        const poseCard = this.createPoseConfigCard(model);
+        container.appendChild(poseCard);
+
+        model.joints.forEach((joint) => {
             if (joint.type === 'fixed') return;
             const control = this.createJointControl(joint, model);
             container.appendChild(control);
         });
+
+        this.refreshAllJointControlsFromModel(model);
+        this.syncPoseValuesTextFromModel(model);
+        this.updatePoseStatusElement();
+    }
+
+    /**
+     * Create pose config card
+     */
+    createPoseConfigCard(model) {
+        const card = document.createElement('div');
+        card.className = 'joint-pose-config';
+
+        const title = document.createElement('div');
+        title.className = 'joint-pose-title';
+        title.textContent = this.t('jointPoseTitle');
+        card.appendChild(title);
+
+        const groupsField = document.createElement('div');
+        groupsField.className = 'joint-pose-field';
+
+        const groupsLabel = document.createElement('label');
+        groupsLabel.className = 'joint-pose-label';
+        groupsLabel.textContent = this.t('jointPoseGroupsField');
+        groupsField.appendChild(groupsLabel);
+
+        const groupsTextarea = document.createElement('textarea');
+        groupsTextarea.className = 'joint-pose-textarea';
+        groupsTextarea.rows = 5;
+        groupsTextarea.spellcheck = false;
+        groupsTextarea.placeholder = this.t('jointPoseGroupsPlaceholder');
+        groupsTextarea.value = this.poseGroupText;
+        groupsField.appendChild(groupsTextarea);
+        card.appendChild(groupsField);
+
+        const valuesField = document.createElement('div');
+        valuesField.className = 'joint-pose-field';
+
+        const valuesLabel = document.createElement('label');
+        valuesLabel.className = 'joint-pose-label';
+        valuesLabel.textContent = this.t('jointPoseValuesField');
+        valuesField.appendChild(valuesLabel);
+
+        const valuesTextarea = document.createElement('textarea');
+        valuesTextarea.className = 'joint-pose-textarea';
+        valuesTextarea.rows = 5;
+        valuesTextarea.spellcheck = false;
+        valuesTextarea.placeholder = this.t('jointPoseValuesPlaceholder');
+        valuesTextarea.value = this.poseValuesText;
+        valuesField.appendChild(valuesTextarea);
+        card.appendChild(valuesField);
+
+        const actions = document.createElement('div');
+        actions.className = 'joint-pose-actions';
+
+        const applyButton = document.createElement('button');
+        applyButton.type = 'button';
+        applyButton.className = 'joint-pose-button primary';
+        applyButton.textContent = this.t('jointPoseApply');
+        actions.appendChild(applyButton);
+
+        const copyButton = document.createElement('button');
+        copyButton.type = 'button';
+        copyButton.className = 'joint-pose-button';
+        copyButton.textContent = this.t('jointPoseCopyValues');
+        actions.appendChild(copyButton);
+
+        card.appendChild(actions);
+
+        const status = document.createElement('div');
+        status.className = 'joint-pose-status';
+        card.appendChild(status);
+
+        groupsTextarea.addEventListener('input', () => {
+            this.poseGroupText = groupsTextarea.value;
+            this.handlePoseTextEdited(model);
+        });
+
+        valuesTextarea.addEventListener('input', () => {
+            this.poseValuesText = valuesTextarea.value;
+            this.handlePoseTextEdited(model);
+        });
+
+        applyButton.addEventListener('click', () => {
+            this.applyPoseConfiguration(model);
+        });
+
+        copyButton.addEventListener('click', async () => {
+            await this.copyPoseValues();
+        });
+
+        this.poseGroupsTextarea = groupsTextarea;
+        this.poseValuesTextarea = valuesTextarea;
+        this.poseStatusElement = status;
+
+        return card;
     }
 
     /**
@@ -144,7 +257,6 @@ export class JointControlsUI {
         const div = document.createElement('div');
         div.className = 'joint-control';
 
-        // First row: name + value
         const header = document.createElement('div');
         header.className = 'joint-header';
 
@@ -152,10 +264,8 @@ export class JointControlsUI {
         name.className = 'joint-name';
         name.textContent = joint.name;
         name.title = joint.name;
-
         header.appendChild(name);
 
-        // Second row: editable limit labels + slider
         const sliderRow = document.createElement('div');
         sliderRow.className = 'joint-slider-row';
 
@@ -174,26 +284,20 @@ export class JointControlsUI {
         slider.setAttribute('data-joint', joint.name);
         slider.min = lower;
         slider.max = upper;
-
-        let initialValue = joint.currentValue !== undefined ? joint.currentValue : (lower + upper) / 2;
-        slider.value = initialValue;
         slider.step = (upper - lower) / 1000;
 
-        // Editable lower limit label
         const minLabel = document.createElement('input');
         minLabel.type = 'number';
         minLabel.className = 'joint-limit-min editable-limit';
         minLabel.step = '0.01';
         minLabel.title = window.i18n.t('clickToEditMin');
 
-        // Editable upper limit label
         const maxLabel = document.createElement('input');
         maxLabel.type = 'number';
         maxLabel.className = 'joint-limit-max editable-limit';
         maxLabel.step = '0.01';
         maxLabel.title = window.i18n.t('clickToEditMax');
 
-        // Predefine valueInput and valueUnit (for updateValueInput function)
         const valueInput = document.createElement('input');
         valueInput.type = 'number';
         valueInput.className = 'joint-value-input';
@@ -202,132 +306,49 @@ export class JointControlsUI {
 
         const valueUnit = document.createElement('span');
         valueUnit.className = 'joint-value-unit';
-        valueUnit.textContent = this.angleUnit === 'deg' ? '°' : 'rad';
 
-        const updateLabels = () => {
-            const currentMin = parseFloat(slider.min);
-            const currentMax = parseFloat(slider.max);
+        const controlState = {
+            joint,
+            slider,
+            minLabel,
+            maxLabel,
+            valueInput,
+            valueUnit,
+            updateLabels: () => {
+                const currentMin = parseFloat(slider.min);
+                const currentMax = parseFloat(slider.max);
 
-            if (this.angleUnit === 'deg') {
-                minLabel.value = (currentMin * 180 / Math.PI).toFixed(1);
-                maxLabel.value = (currentMax * 180 / Math.PI).toFixed(1);
-            } else {
-                minLabel.value = currentMin.toFixed(2);
-                maxLabel.value = currentMax.toFixed(2);
+                if (this.angleUnit === 'deg') {
+                    minLabel.value = (currentMin * 180 / Math.PI).toFixed(1);
+                    maxLabel.value = (currentMax * 180 / Math.PI).toFixed(1);
+                } else {
+                    minLabel.value = currentMin.toFixed(2);
+                    maxLabel.value = currentMax.toFixed(2);
+                }
+            },
+            updateValueInput: () => {
+                const currentValue = this.getJointCurrentValue(model, joint.name);
+                valueInput.value = this.angleUnit === 'deg'
+                    ? (currentValue * 180 / Math.PI).toFixed(1)
+                    : currentValue.toFixed(2);
+                valueUnit.textContent = this.angleUnit === 'deg' ? '°' : 'rad';
+            },
+            updateDisplay: () => {
+                slider.value = this.getJointCurrentValue(model, joint.name);
+                controlState.updateValueInput();
+                controlState.updateLabels();
             }
         };
 
-        const updateValueInput = () => {
-            const value = parseFloat(slider.value);
-            valueInput.value = this.angleUnit === 'deg' ?
-                (value * 180 / Math.PI).toFixed(1) :
-                value.toFixed(2);
-        };
-
-        updateLabels();
-        updateValueInput();
-
-        // Lower limit edit event
-        minLabel.addEventListener('change', () => {
-            let inputValue = parseFloat(minLabel.value);
-            if (isNaN(inputValue)) {
-                updateLabels();
-                return;
-            }
-
-            let valueInRad = this.angleUnit === 'deg' ?
-                inputValue * Math.PI / 180 :
-                inputValue;
-
-            const currentMax = parseFloat(slider.max);
-            if (valueInRad >= currentMax) {
-                updateLabels();
-                return;
-            }
-
-            slider.min = valueInRad;
-            slider.step = (slider.max - slider.min) / 1000;
-
-            // Update limits in model
-            if (joint.limits) {
-                joint.limits.lower = valueInRad;
-            }
-
-            // Sync to editor
-            this.updateEditorXML(joint.name, { lower: valueInRad });
-
-            // If current value exceeds new limit, adjust to within limit
-            const currentValue = parseFloat(slider.value);
-            if (currentValue < valueInRad) {
-                slider.value = valueInRad;
-                ModelLoaderFactory.setJointAngle(model, joint.name, valueInRad);
-                joint.currentValue = valueInRad;
-                updateValueInput();
-                this.sceneManager.redraw();
-                this.sceneManager.render();
-
-                // Trigger measurement update
-                if (this.sceneManager.onMeasurementUpdate) {
-                    this.sceneManager.onMeasurementUpdate();
-                }
-            }
-
-            updateLabels();
-        });
-
-        // Upper limit edit event
-        maxLabel.addEventListener('change', () => {
-            let inputValue = parseFloat(maxLabel.value);
-            if (isNaN(inputValue)) {
-                updateLabels();
-                return;
-            }
-
-            let valueInRad = this.angleUnit === 'deg' ?
-                inputValue * Math.PI / 180 :
-                inputValue;
-
-            const currentMin = parseFloat(slider.min);
-            if (valueInRad <= currentMin) {
-                updateLabels();
-                return;
-            }
-
-            slider.max = valueInRad;
-            slider.step = (slider.max - slider.min) / 1000;
-
-            // Update limits in model
-            if (joint.limits) {
-                joint.limits.upper = valueInRad;
-            }
-
-            // Sync to editor
-            this.updateEditorXML(joint.name, { upper: valueInRad });
-
-            // If current value exceeds new limit, adjust to within limit
-            const currentValue = parseFloat(slider.value);
-            if (currentValue > valueInRad) {
-                slider.value = valueInRad;
-                ModelLoaderFactory.setJointAngle(model, joint.name, valueInRad);
-                joint.currentValue = valueInRad;
-                updateValueInput();
-                this.sceneManager.redraw();
-                this.sceneManager.render();
-
-                // Trigger measurement update
-                if (this.sceneManager.onMeasurementUpdate) {
-                    this.sceneManager.onMeasurementUpdate();
-                }
-            }
-
-            updateLabels();
-        });
+        const initialValue = this.getJointCurrentValue(model, joint.name);
+        slider.value = initialValue;
+        controlState.updateLabels();
+        controlState.updateValueInput();
 
         const sliderContainer = document.createElement('div');
         sliderContainer.className = 'joint-slider-container';
         sliderContainer.appendChild(slider);
 
-        // Value input container (placed after slider)
         const valueInputContainer = document.createElement('div');
         valueInputContainer.className = 'joint-value-input-container';
         valueInputContainer.appendChild(valueInput);
@@ -338,17 +359,15 @@ export class JointControlsUI {
         sliderRow.appendChild(maxLabel);
         sliderRow.appendChild(valueInputContainer);
 
-        // Determine model type (URDF only shows effort and velocity)
         const modelType = model.threeObject?.userData?.type || 'urdf';
         const showEffortVelocity = modelType === 'urdf';
 
-        // Effort control (only shown in URDF)
         if (showEffortVelocity) {
             const effortContainer = document.createElement('div');
             effortContainer.className = 'joint-extra-field';
 
             const effortLabel = document.createElement('label');
-            effortLabel.textContent = 'τ:';
+            effortLabel.textContent = 't:';
             effortLabel.className = 'joint-extra-label';
             effortLabel.title = 'Effort (max force/torque)';
 
@@ -356,16 +375,13 @@ export class JointControlsUI {
             effortInput.type = 'number';
             effortInput.className = 'joint-extra-input';
             effortInput.step = '0.1';
-            // Read actual value from model, show empty string if not available
-            const effortValue = limits.effort !== null && limits.effort !== undefined ? limits.effort : '';
-            effortInput.value = effortValue;
+            effortInput.value = limits.effort !== null && limits.effort !== undefined ? limits.effort : '';
             effortInput.placeholder = '-';
             effortInput.title = 'Effort (max force/torque)';
 
             effortContainer.appendChild(effortLabel);
             effortContainer.appendChild(effortInput);
 
-            // Velocity control
             const velocityContainer = document.createElement('div');
             velocityContainer.className = 'joint-extra-field';
 
@@ -378,28 +394,23 @@ export class JointControlsUI {
             velocityInput.type = 'number';
             velocityInput.className = 'joint-extra-input';
             velocityInput.step = '0.1';
-            // Read actual value from model, show empty string if not available
-            const velocityValue = limits.velocity !== null && limits.velocity !== undefined ? limits.velocity : '';
-            velocityInput.value = velocityValue;
+            velocityInput.value = limits.velocity !== null && limits.velocity !== undefined ? limits.velocity : '';
             velocityInput.placeholder = '-';
             velocityInput.title = 'Velocity (max speed)';
 
             velocityContainer.appendChild(velocityLabel);
             velocityContainer.appendChild(velocityInput);
 
-            // Add Effort and Velocity to first row
             header.appendChild(effortContainer);
             header.appendChild(velocityContainer);
 
-            // Effort input event
             effortInput.addEventListener('change', () => {
-                let inputValue = parseFloat(effortInput.value);
-                if (isNaN(inputValue) || effortInput.value === '') {
-                    // If input is empty or invalid, set to null
+                const inputValue = parseFloat(effortInput.value);
+                if (Number.isNaN(inputValue) || effortInput.value === '') {
                     if (!joint.limits) {
                         joint.limits = {
-                            lower: lower,
-                            upper: upper,
+                            lower,
+                            upper,
                             effort: null,
                             velocity: limits.velocity
                         };
@@ -411,8 +422,8 @@ export class JointControlsUI {
 
                 if (!joint.limits) {
                     joint.limits = {
-                        lower: lower,
-                        upper: upper,
+                        lower,
+                        upper,
                         effort: inputValue,
                         velocity: limits.velocity
                     };
@@ -420,19 +431,16 @@ export class JointControlsUI {
                     joint.limits.effort = inputValue;
                 }
 
-                // Sync to editor
                 this.updateEditorXML(joint.name, { effort: inputValue });
             });
 
-            // Velocity input event
             velocityInput.addEventListener('change', () => {
-                let inputValue = parseFloat(velocityInput.value);
-                if (isNaN(inputValue) || velocityInput.value === '') {
-                    // If input is empty or invalid, set to null
+                const inputValue = parseFloat(velocityInput.value);
+                if (Number.isNaN(inputValue) || velocityInput.value === '') {
                     if (!joint.limits) {
                         joint.limits = {
-                            lower: lower,
-                            upper: upper,
+                            lower,
+                            upper,
                             effort: limits.effort,
                             velocity: null
                         };
@@ -444,8 +452,8 @@ export class JointControlsUI {
 
                 if (!joint.limits) {
                     joint.limits = {
-                        lower: lower,
-                        upper: upper,
+                        lower,
+                        upper,
                         effort: limits.effort,
                         velocity: inputValue
                     };
@@ -453,12 +461,10 @@ export class JointControlsUI {
                     joint.limits.velocity = inputValue;
                 }
 
-                // Sync to editor
                 this.updateEditorXML(joint.name, { velocity: inputValue });
             });
         }
 
-        // Slider events
         slider.addEventListener('mousedown', () => {
             this.sceneManager.axesManager.showOnlyJointAxis(joint);
         });
@@ -467,134 +473,270 @@ export class JointControlsUI {
             this.sceneManager.axesManager.restoreAllJointAxes();
         });
 
-        div.appendChild(header);
-        div.appendChild(sliderRow);
-
         slider.addEventListener('input', () => {
             const value = parseFloat(slider.value);
-            ModelLoaderFactory.setJointAngle(model, joint.name, value);
-            joint.currentValue = value;
-            updateValueInput();
-
-            // Apply parallel mechanism constraints
-            if (this.sceneManager.constraintManager) {
-                this.sceneManager.constraintManager.applyConstraints(model, joint);
-            }
+            this.applyJointValueChange(model, joint.name, value, {
+                render: false
+            });
 
             if (!slider._pendingRender) {
                 slider._pendingRender = true;
                 requestAnimationFrame(() => {
-                    this.sceneManager.redraw();
-                    this.sceneManager.render();
-
-                    // Trigger measurement update
-                    if (this.sceneManager.onMeasurementUpdate) {
-                        this.sceneManager.onMeasurementUpdate();
-                    }
-
+                    this.finalizeJointUpdates();
                     slider._pendingRender = false;
                 });
             }
         });
 
-        // Manual input event
         valueInput.addEventListener('change', () => {
-            let inputValue = parseFloat(valueInput.value);
-            if (isNaN(inputValue)) {
-                updateValueInput();
+            const inputValue = parseFloat(valueInput.value);
+            if (Number.isNaN(inputValue)) {
+                controlState.updateValueInput();
                 return;
             }
 
-            let valueInRad = this.angleUnit === 'deg' ?
-                inputValue * Math.PI / 180 :
-                inputValue;
+            const valueInRad = this.angleUnit === 'deg'
+                ? inputValue * Math.PI / 180
+                : inputValue;
 
-            const currentMin = parseFloat(slider.min);
-            const currentMax = parseFloat(slider.max);
-            valueInRad = Math.max(currentMin, Math.min(currentMax, valueInRad));
+            this.applyJointValueChange(model, joint.name, valueInRad);
+        });
 
-            slider.value = valueInRad;
-            ModelLoaderFactory.setJointAngle(model, joint.name, valueInRad);
-            joint.currentValue = valueInRad;
-
-            // Apply parallel mechanism constraints
-            if (this.sceneManager.constraintManager) {
-                this.sceneManager.constraintManager.applyConstraints(model, joint);
+        minLabel.addEventListener('change', () => {
+            const inputValue = parseFloat(minLabel.value);
+            if (Number.isNaN(inputValue)) {
+                controlState.updateLabels();
+                return;
             }
 
-            updateValueInput();
-            this.sceneManager.redraw();
-            this.sceneManager.render();
+            const valueInRad = this.angleUnit === 'deg'
+                ? inputValue * Math.PI / 180
+                : inputValue;
 
-            // Trigger measurement update
-            if (this.sceneManager.onMeasurementUpdate) {
-                this.sceneManager.onMeasurementUpdate();
+            const currentMax = parseFloat(slider.max);
+            if (valueInRad >= currentMax) {
+                controlState.updateLabels();
+                return;
+            }
+
+            slider.min = valueInRad;
+            slider.step = (parseFloat(slider.max) - parseFloat(slider.min)) / 1000;
+
+            if (joint.limits) {
+                joint.limits.lower = valueInRad;
+            }
+
+            this.updateEditorXML(joint.name, { lower: valueInRad });
+
+            if (this.getJointCurrentValue(model, joint.name) < valueInRad) {
+                this.applyJointValueChange(model, joint.name, valueInRad);
+            } else {
+                controlState.updateLabels();
             }
         });
 
-        // Save update function
-        div._updateDisplay = () => {
-            updateValueInput();
-            updateLabels();
-            valueUnit.textContent = this.angleUnit === 'deg' ? '°' : 'rad';
-        };
+        maxLabel.addEventListener('change', () => {
+            const inputValue = parseFloat(maxLabel.value);
+            if (Number.isNaN(inputValue)) {
+                controlState.updateLabels();
+                return;
+            }
+
+            const valueInRad = this.angleUnit === 'deg'
+                ? inputValue * Math.PI / 180
+                : inputValue;
+
+            const currentMin = parseFloat(slider.min);
+            if (valueInRad <= currentMin) {
+                controlState.updateLabels();
+                return;
+            }
+
+            slider.max = valueInRad;
+            slider.step = (parseFloat(slider.max) - parseFloat(slider.min)) / 1000;
+
+            if (joint.limits) {
+                joint.limits.upper = valueInRad;
+            }
+
+            this.updateEditorXML(joint.name, { upper: valueInRad });
+
+            if (this.getJointCurrentValue(model, joint.name) > valueInRad) {
+                this.applyJointValueChange(model, joint.name, valueInRad);
+            } else {
+                controlState.updateLabels();
+            }
+        });
+
+        div.appendChild(header);
+        div.appendChild(sliderRow);
+        div._updateDisplay = controlState.updateDisplay;
+
+        this.jointControlElements.set(joint.name, controlState);
 
         return div;
     }
 
     /**
-     * Set angle unit
+     * Apply pose configuration from textareas
      */
-    setAngleUnit(unit) {
-        this.angleUnit = unit;
-        const controls = document.querySelectorAll('.joint-control');
-        controls.forEach(control => {
-            if (control._updateDisplay) {
-                control._updateDisplay();
+    applyPoseConfiguration(model) {
+        try {
+            const groupText = this.poseGroupsTextarea ? this.poseGroupsTextarea.value : this.poseGroupText;
+            const valueText = this.poseValuesTextarea ? this.poseValuesTextarea.value : this.poseValuesText;
+
+            this.poseGroupText = groupText;
+            this.poseValuesText = valueText;
+
+            const groupConfig = this.parsePoseYamlMap(groupText, 'groups');
+            const valueConfig = this.parsePoseYamlMap(valueText, 'values');
+            const validatedConfig = this.validatePoseConfigs(model, groupConfig, valueConfig);
+
+            this.activePoseConfig = {
+                groups: validatedConfig.groups.map((group) => ({
+                    name: group.name,
+                    joints: [...group.joints]
+                }))
+            };
+            this.activePoseModel = model;
+
+            let clampedCount = 0;
+
+            validatedConfig.groups.forEach((group) => {
+                group.joints.forEach((jointName, index) => {
+                    const result = this.applyJointValueChange(model, jointName, group.values[index], {
+                        render: false,
+                        syncPoseValues: false,
+                        refreshControls: false
+                    });
+
+                    if (result.wasClamped) {
+                        clampedCount++;
+                    }
+                });
+            });
+
+            this.refreshAllJointControlsFromModel(model);
+            this.syncPoseValuesTextFromModel(model);
+            this.finalizeJointUpdates();
+
+            if (clampedCount > 0) {
+                this.setPoseStatus('warning', 'jointPoseApplyClamped', { count: clampedCount });
+            } else {
+                this.setPoseStatus('success', 'jointPoseApplySuccess');
             }
-        });
+        } catch (error) {
+            this.setPoseStatus('error', null, {}, error.message);
+        }
     }
 
     /**
-     * Reset all joints to initial positions when model loaded
+     * Copy pose values text
+     */
+    async copyPoseValues() {
+        const text = this.poseValuesTextarea ? this.poseValuesTextarea.value : this.poseValuesText;
+
+        try {
+            await this.copyTextToClipboard(text);
+            this.setPoseStatus('success', 'jointPoseCopySuccess');
+        } catch (error) {
+            this.setPoseStatus('error', 'jointPoseCopyFailed', {
+                reason: error.message || this.t('jointPoseClipboardUnavailable')
+            });
+        }
+    }
+
+    /**
+     * Sync UI after an external joint update such as 3D dragging
+     */
+    handleExternalJointValueChange(model) {
+        this.refreshAllJointControlsFromModel(model);
+        this.syncPoseValuesTextFromModel(model);
+    }
+
+    /**
+     * Update a single joint value and keep the panel in sync
+     */
+    applyJointValueChange(model, jointName, requestedValue, options = {}) {
+        const joint = model?.joints?.get(jointName);
+        if (!joint || joint.type === 'fixed') {
+            return {
+                requestedValue,
+                appliedValue: requestedValue,
+                wasClamped: false
+            };
+        }
+
+        const control = this.jointControlElements.get(jointName);
+        let appliedValue = requestedValue;
+
+        if (options.clampToSliderRange !== false && control) {
+            const min = parseFloat(control.slider.min);
+            const max = parseFloat(control.slider.max);
+
+            if (Number.isFinite(min) && Number.isFinite(max)) {
+                appliedValue = Math.max(min, Math.min(max, appliedValue));
+            }
+        }
+
+        ModelLoaderFactory.setJointAngle(model, jointName, appliedValue, options.ignoreLimits === true);
+        joint.currentValue = appliedValue;
+
+        if (this.sceneManager.constraintManager) {
+            this.sceneManager.constraintManager.applyConstraints(model, joint);
+        }
+
+        if (options.refreshControls !== false) {
+            this.refreshAllJointControlsFromModel(model);
+        }
+
+        if (options.syncPoseValues !== false) {
+            this.syncPoseValuesTextFromModel(model);
+        }
+
+        if (options.render !== false) {
+            this.finalizeJointUpdates();
+        }
+
+        return {
+            requestedValue,
+            appliedValue,
+            wasClamped: Math.abs(appliedValue - requestedValue) > 1e-9
+        };
+    }
+
+    /**
+     * Reset all joints to their initial values
      */
     resetAllJoints(model) {
         if (!model || !model.joints) return;
 
         model.joints.forEach((joint, name) => {
-            if (joint.type !== 'fixed') {
-                // Use saved initial value, if not saved use middle value
-                let initialValue = this.initialJointValues.get(name);
-
-                if (initialValue === undefined) {
-                    const limits = joint.limits || {};
-                    const lower = limits.lower !== undefined ? limits.lower : -Math.PI;
-                    const upper = limits.upper !== undefined ? limits.upper : Math.PI;
-                    initialValue = joint.currentValue !== undefined ? joint.currentValue : (lower + upper) / 2;
-                }
-
-                // Set joint angle, ignore limit constraints because initial position may exceed current limits
-                ModelLoaderFactory.setJointAngle(model, name, initialValue, true);
-
-                joint.currentValue = initialValue;
-
-                const slider = document.querySelector(`input[data-joint="${name}"]`);
-                if (slider) {
-                    slider.value = initialValue;
-                    const control = slider.closest('.joint-control');
-                    if (control && control._updateDisplay) {
-                        control._updateDisplay();
-                    }
-                }
+            if (joint.type === 'fixed') {
+                return;
             }
+
+            let initialValue = this.initialJointValues.get(name);
+
+            if (initialValue === undefined) {
+                const limits = joint.limits || {};
+                const lower = limits.lower !== undefined ? limits.lower : -Math.PI;
+                const upper = limits.upper !== undefined ? limits.upper : Math.PI;
+                initialValue = joint.currentValue !== undefined ? joint.currentValue : (lower + upper) / 2;
+            }
+
+            this.applyJointValueChange(model, name, initialValue, {
+                clampToSliderRange: false,
+                ignoreLimits: true,
+                render: false,
+                syncPoseValues: false,
+                refreshControls: false
+            });
         });
 
-        this.sceneManager.render();
-
-        // Trigger measurement update
-        if (this.sceneManager.onMeasurementUpdate) {
-            this.sceneManager.onMeasurementUpdate();
-        }
+        this.refreshAllJointControlsFromModel(model);
+        this.syncPoseValuesTextFromModel(model);
+        this.finalizeJointUpdates();
     }
 
     /**
@@ -603,35 +745,375 @@ export class JointControlsUI {
     updateAllSliderLimits(model, ignoreLimits) {
         if (!model) return;
 
-        document.querySelectorAll('.joint-slider').forEach(slider => {
-            const jointName = slider.getAttribute('data-joint');
+        this.jointControlElements.forEach((control, jointName) => {
             const joint = model.joints.get(jointName);
-
-            if (joint && joint.type !== 'fixed') {
-                if (ignoreLimits) {
-                    slider.min = -Math.PI * 2;
-                    slider.max = Math.PI * 2;
-                    slider.step = 0.01;
-                } else {
-                    const limits = joint.limits || {};
-                    const lower = limits.lower !== undefined ? limits.lower : -Math.PI;
-                    const upper = limits.upper !== undefined ? limits.upper : Math.PI;
-
-                    if (joint.type === 'continuous') {
-                        slider.min = -Math.PI;
-                        slider.max = Math.PI;
-                    } else {
-                        slider.min = lower;
-                        slider.max = upper;
-                    }
-                    slider.step = (slider.max - slider.min) / 1000;
-                }
-
-                const control = slider.closest('.joint-control');
-                if (control && control._updateDisplay) {
-                    control._updateDisplay();
-                }
+            if (!joint || joint.type === 'fixed') {
+                return;
             }
+
+            if (ignoreLimits) {
+                control.slider.min = -Math.PI * 2;
+                control.slider.max = Math.PI * 2;
+                control.slider.step = 0.01;
+            } else {
+                const limits = joint.limits || {};
+                const lower = limits.lower !== undefined ? limits.lower : -Math.PI;
+                const upper = limits.upper !== undefined ? limits.upper : Math.PI;
+
+                if (joint.type === 'continuous') {
+                    control.slider.min = -Math.PI;
+                    control.slider.max = Math.PI;
+                } else {
+                    control.slider.min = lower;
+                    control.slider.max = upper;
+                }
+                control.slider.step = (parseFloat(control.slider.max) - parseFloat(control.slider.min)) / 1000;
+            }
+
+            control.updateDisplay();
+        });
+
+        this.syncPoseValuesTextFromModel(model);
+    }
+
+    /**
+     * Set angle unit
+     */
+    setAngleUnit(unit) {
+        this.angleUnit = unit;
+        this.refreshAllJointControlsFromModel(this.activePoseModel || this.initialValueModel);
+    }
+
+    /**
+     * Refresh all control displays from the model
+     */
+    refreshAllJointControlsFromModel(model) {
+        if (!model) return;
+
+        this.jointControlElements.forEach((control) => {
+            control.updateDisplay();
+        });
+    }
+
+    /**
+     * Sync pose values text from the active pose config
+     */
+    syncPoseValuesTextFromModel(model) {
+        if (!this.activePoseConfig || this.activePoseModel !== model) {
+            return;
+        }
+
+        const yamlText = this.buildPoseValuesYaml(model, this.activePoseConfig);
+        this.poseValuesText = yamlText;
+
+        if (this.poseValuesTextarea) {
+            this.poseValuesTextarea.value = yamlText;
+        }
+    }
+
+    /**
+     * Parse YAML for pose config
+     */
+    parsePoseYamlMap(text, fieldType) {
+        const fieldLabel = this.t(fieldType === 'groups' ? 'jointPoseGroupsField' : 'jointPoseValuesField');
+
+        if (!text || text.trim().length === 0) {
+            throw new Error(this.t(fieldType === 'groups' ? 'jointPoseGroupsRequired' : 'jointPoseValuesRequired'));
+        }
+
+        let document;
+        try {
+            document = YAML.parseDocument(text);
+        } catch (error) {
+            throw new Error(this.formatMessage('jointPoseYamlParseFailed', {
+                field: fieldLabel,
+                reason: error.message
+            }));
+        }
+
+        if (document.errors.length > 0) {
+            throw new Error(this.formatMessage('jointPoseYamlParseFailed', {
+                field: fieldLabel,
+                reason: document.errors[0].message
+            }));
+        }
+
+        if (!isMap(document.contents)) {
+            throw new Error(this.formatMessage('jointPoseMappingExpected', {
+                field: fieldLabel
+            }));
+        }
+
+        const orderedGroups = [];
+        const values = new Map();
+
+        document.contents.items.forEach((item) => {
+            const groupName = String(item.key?.toJSON?.() ?? item.key?.value ?? '').trim();
+
+            if (!groupName) {
+                throw new Error(this.formatMessage('jointPoseGroupNameRequired', {
+                    field: fieldLabel
+                }));
+            }
+
+            if (values.has(groupName)) {
+                throw new Error(this.formatMessage('jointPoseGroupDuplicate', {
+                    field: fieldLabel,
+                    group: groupName
+                }));
+            }
+
+            if (!isSeq(item.value)) {
+                throw new Error(this.formatMessage('jointPoseSequenceExpected', {
+                    field: fieldLabel,
+                    group: groupName
+                }));
+            }
+
+            const sequence = item.value.toJSON();
+            if (!Array.isArray(sequence)) {
+                throw new Error(this.formatMessage('jointPoseSequenceExpected', {
+                    field: fieldLabel,
+                    group: groupName
+                }));
+            }
+
+            const normalized = sequence.map((entry, index) => {
+                if (fieldType === 'groups') {
+                    if (typeof entry !== 'string' || !entry.trim()) {
+                        throw new Error(this.formatMessage('jointPoseJointNameInvalid', {
+                            field: fieldLabel,
+                            group: groupName,
+                            index: index + 1
+                        }));
+                    }
+                    return entry.trim();
+                }
+
+                const numericValue = typeof entry === 'number' ? entry : Number(entry);
+                if (!Number.isFinite(numericValue)) {
+                    throw new Error(this.formatMessage('jointPoseValueInvalid', {
+                        field: fieldLabel,
+                        group: groupName,
+                        index: index + 1
+                    }));
+                }
+                return numericValue;
+            });
+
+            orderedGroups.push(groupName);
+            values.set(groupName, normalized);
+        });
+
+        return { orderedGroups, values };
+    }
+
+    /**
+     * Validate pose configs against the current model
+     */
+    validatePoseConfigs(model, groupConfig, valueConfig) {
+        if (groupConfig.orderedGroups.length !== valueConfig.orderedGroups.length) {
+            throw new Error(this.t('jointPoseGroupMismatch'));
+        }
+
+        const groups = [];
+        const seenJoints = new Set();
+
+        groupConfig.orderedGroups.forEach((groupName, index) => {
+            const valueGroupName = valueConfig.orderedGroups[index];
+            if (groupName !== valueGroupName) {
+                throw new Error(this.t('jointPoseGroupOrderMismatch'));
+            }
+
+            const joints = groupConfig.values.get(groupName) || [];
+            const values = valueConfig.values.get(groupName) || [];
+
+            if (joints.length !== values.length) {
+                throw new Error(this.formatMessage('jointPoseLengthMismatch', {
+                    group: groupName,
+                    jointCount: joints.length,
+                    valueCount: values.length
+                }));
+            }
+
+            joints.forEach((jointName) => {
+                if (seenJoints.has(jointName)) {
+                    throw new Error(this.formatMessage('jointPoseJointDuplicate', {
+                        joint: jointName
+                    }));
+                }
+
+                const joint = model.joints.get(jointName);
+                if (!joint) {
+                    throw new Error(this.formatMessage('jointPoseJointMissing', {
+                        joint: jointName
+                    }));
+                }
+
+                if (joint.type === 'fixed') {
+                    throw new Error(this.formatMessage('jointPoseJointFixed', {
+                        joint: jointName
+                    }));
+                }
+
+                seenJoints.add(jointName);
+            });
+
+            groups.push({
+                name: groupName,
+                joints: [...joints],
+                values: [...values]
+            });
+        });
+
+        return { groups };
+    }
+
+    /**
+     * Build values YAML from the active groups
+     */
+    buildPoseValuesYaml(model, config) {
+        return config.groups.map((group) => {
+            const values = group.joints.map((jointName) => {
+                return this.formatPoseNumber(this.getJointCurrentValue(model, jointName));
+            });
+            return `${group.name}: [${values.join(', ')}]`;
+        }).join('\n');
+    }
+
+    /**
+     * Handle textarea edits
+     */
+    handlePoseTextEdited(model) {
+        if (this.activePoseConfig && this.activePoseModel === model) {
+            this.activePoseConfig = null;
+            this.activePoseModel = null;
+            this.setPoseStatus('info', 'jointPoseConfigEdited');
+        }
+    }
+
+    /**
+     * Finalize joint updates with one render and measurement refresh
+     */
+    finalizeJointUpdates() {
+        this.sceneManager.redraw();
+        this.sceneManager.render();
+
+        if (this.sceneManager.onMeasurementUpdate) {
+            this.sceneManager.onMeasurementUpdate();
+        }
+    }
+
+    /**
+     * Get the current joint value
+     */
+    getJointCurrentValue(model, jointName) {
+        const joint = model?.joints?.get(jointName);
+        if (!joint) {
+            return 0;
+        }
+
+        if (typeof joint.currentValue === 'number' && Number.isFinite(joint.currentValue)) {
+            return joint.currentValue;
+        }
+
+        const control = this.jointControlElements.get(jointName);
+        if (control) {
+            const sliderValue = parseFloat(control.slider.value);
+            if (Number.isFinite(sliderValue)) {
+                return sliderValue;
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * Format a joint value for exported YAML
+     */
+    formatPoseNumber(value) {
+        let rounded = Number(value.toFixed(6));
+        if (Object.is(rounded, -0) || Math.abs(rounded) < 1e-9) {
+            rounded = 0;
+        }
+
+        const normalized = rounded.toString();
+        return normalized.includes('.') ? normalized : `${normalized}.0`;
+    }
+
+    /**
+     * Copy text to the clipboard
+     */
+    async copyTextToClipboard(text) {
+        if (navigator.clipboard?.writeText) {
+            await navigator.clipboard.writeText(text);
+            return;
+        }
+
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+
+        const copied = document.execCommand('copy');
+        document.body.removeChild(textarea);
+
+        if (!copied) {
+            throw new Error(this.t('jointPoseClipboardUnavailable'));
+        }
+    }
+
+    /**
+     * Update pose status state and element
+     */
+    setPoseStatus(type, key = null, params = {}, rawMessage = '') {
+        this.poseStatus = {
+            type,
+            key,
+            params,
+            rawMessage
+        };
+        this.updatePoseStatusElement();
+    }
+
+    /**
+     * Update the rendered pose status element
+     */
+    updatePoseStatusElement() {
+        if (!this.poseStatusElement) {
+            return;
+        }
+
+        const status = this.poseStatus;
+        const statusText = status
+            ? (status.key ? this.formatMessage(status.key, status.params) : status.rawMessage)
+            : '';
+
+        this.poseStatusElement.textContent = statusText;
+        this.poseStatusElement.className = 'joint-pose-status';
+
+        if (status?.type) {
+            this.poseStatusElement.classList.add(status.type);
+        }
+    }
+
+    /**
+     * Translate a key
+     */
+    t(key) {
+        return window.i18n?.t(key) || key;
+    }
+
+    /**
+     * Replace template placeholders in translated text
+     */
+    formatMessage(key, params = {}) {
+        const template = this.t(key);
+        return template.replace(/\{(\w+)\}/g, (_, token) => {
+            return params[token] !== undefined ? String(params[token]) : '';
         });
     }
 }

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -48,6 +48,37 @@ export const translations = {
         'unsaved': '未保存',
         'noFileOpen': '未打开文件',
 
+        // 姿态配置
+        'jointPoseTitle': '姿态配置',
+        'jointPoseGroupsField': '关节分组',
+        'jointPoseValuesField': '姿态数值 (rad)',
+        'jointPoseApply': '应用',
+        'jointPoseCopyValues': '复制数值',
+        'jointPoseGroupsPlaceholder': 'waist: [joint_a, joint_b]\narm: [joint_c, joint_d]',
+        'jointPoseValuesPlaceholder': 'waist: [0.0, 0.0]\narm: [0.9, -0.9]',
+        'jointPoseConfigEdited': '姿态配置已修改，点击“应用”后恢复联动。',
+        'jointPoseReapplyRequired': '已保留姿态配置，请对当前模型重新点击“应用”。',
+        'jointPoseApplySuccess': '姿态应用成功。',
+        'jointPoseApplyClamped': '姿态已应用，有 {count} 个关节值被裁剪到当前限位范围。',
+        'jointPoseCopySuccess': '姿态数值已复制。',
+        'jointPoseCopyFailed': '复制姿态数值失败：{reason}',
+        'jointPoseClipboardUnavailable': '当前环境不支持剪贴板复制。',
+        'jointPoseGroupsRequired': '请先填写关节分组 YAML。',
+        'jointPoseValuesRequired': '请先填写姿态数值 YAML。',
+        'jointPoseYamlParseFailed': '解析 {field} 失败：{reason}',
+        'jointPoseMappingExpected': '{field} 必须是 YAML 映射。',
+        'jointPoseSequenceExpected': '{field}.{group} 必须是数组。',
+        'jointPoseGroupNameRequired': '{field} 中包含空的分组名称。',
+        'jointPoseGroupDuplicate': '{field} 中的分组 {group} 重复定义。',
+        'jointPoseJointNameInvalid': '{field}.{group}[{index}] 必须是非空关节名字符串。',
+        'jointPoseValueInvalid': '{field}.{group}[{index}] 必须是有限数字。',
+        'jointPoseGroupMismatch': '关节分组和姿态数值必须包含完全相同的分组。',
+        'jointPoseGroupOrderMismatch': '姿态数值的分组顺序必须与关节分组一致。',
+        'jointPoseLengthMismatch': '分组 {group} 中关节数量为 {jointCount}，数值数量为 {valueCount}。',
+        'jointPoseJointMissing': '当前模型中不存在关节 {joint}。',
+        'jointPoseJointFixed': '关节 {joint} 是 fixed，无法控制。',
+        'jointPoseJointDuplicate': '关节 {joint} 被重复分配。',
+
         // 帮助对话框
         'helpTitle': `Robot Viewer v${APP_VERSION}`,
         'about': '关于',
@@ -170,6 +201,37 @@ export const translations = {
         'saved': 'Saved',
         'unsaved': 'Unsaved',
         'noFileOpen': 'No File Open',
+
+        // Pose config
+        'jointPoseTitle': 'Pose Config',
+        'jointPoseGroupsField': 'Joint Groups',
+        'jointPoseValuesField': 'Pose Values (rad)',
+        'jointPoseApply': 'Apply',
+        'jointPoseCopyValues': 'Copy Values',
+        'jointPoseGroupsPlaceholder': 'waist: [joint_a, joint_b]\narm: [joint_c, joint_d]',
+        'jointPoseValuesPlaceholder': 'waist: [0.0, 0.0]\narm: [0.9, -0.9]',
+        'jointPoseConfigEdited': 'Pose config changed. Click Apply to resume syncing.',
+        'jointPoseReapplyRequired': 'Pose config was kept. Click Apply to use it with the current model.',
+        'jointPoseApplySuccess': 'Pose applied successfully.',
+        'jointPoseApplyClamped': 'Pose applied. {count} joint values were clamped to the current limits.',
+        'jointPoseCopySuccess': 'Pose values copied to clipboard.',
+        'jointPoseCopyFailed': 'Failed to copy pose values: {reason}',
+        'jointPoseClipboardUnavailable': 'Clipboard is unavailable in this browser context.',
+        'jointPoseGroupsRequired': 'Joint groups YAML is required.',
+        'jointPoseValuesRequired': 'Pose values YAML is required.',
+        'jointPoseYamlParseFailed': 'Failed to parse {field}: {reason}',
+        'jointPoseMappingExpected': '{field} must be a YAML mapping.',
+        'jointPoseSequenceExpected': '{field}.{group} must be an array.',
+        'jointPoseGroupNameRequired': '{field} contains an empty group name.',
+        'jointPoseGroupDuplicate': 'Group {group} is declared more than once in {field}.',
+        'jointPoseJointNameInvalid': '{field}.{group}[{index}] must be a non-empty joint name string.',
+        'jointPoseValueInvalid': '{field}.{group}[{index}] must be a finite number.',
+        'jointPoseGroupMismatch': 'Joint groups and pose values must contain the same groups.',
+        'jointPoseGroupOrderMismatch': 'Pose values must use the same group order as joint groups.',
+        'jointPoseLengthMismatch': 'Group {group} has {jointCount} joints but {valueCount} values.',
+        'jointPoseJointMissing': 'Joint {joint} does not exist in the current model.',
+        'jointPoseJointFixed': 'Joint {joint} is fixed and cannot be controlled.',
+        'jointPoseJointDuplicate': 'Joint {joint} is assigned more than once.',
 
         // Help dialog
         'helpTitle': `Robot Viewer v${APP_VERSION}`,
@@ -337,5 +399,4 @@ class I18n {
 
 // 创建全局实例
 export const i18n = new I18n();
-
 


### PR DESCRIPTION
## Summary

This PR adds a pose configuration section to the joint panel, allowing grouped joint poses to be imported and exported with YAML.

Users can now:
- define `group -> joint names[]`
- define `group -> values[]` in radians
- apply grouped poses to the robot in one click
- copy the current grouped pose values for saving/reuse

Once a pose group mapping is activated, joint values stay in sync in both directions:
- applying pose values updates the robot and all joint controls
- moving sliders / editing joint inputs updates the pose values YAML
- resetting joints updates the pose values YAML
- dragging joints in the 3D view updates the pose values YAML

## What changed

- Added a pose config card at the top of the joint panel
  - `Joint Groups` YAML textarea
  - `Pose Values (rad)` YAML textarea
  - `Apply` button
  - `Copy Values` button
  - inline status / validation messages

- Added YAML parsing and validation for pose config
  - preserves group order
  - requires matching groups between joint definitions and value definitions
  - validates array lengths
  - rejects missing joints
  - rejects fixed joints
  - rejects duplicated joint assignments
  - rejects non-numeric values

- Centralized joint value updates inside `JointControlsUI`
  - joint assignment
  - `joint.currentValue`
  - slider / input refresh
  - constraint application
  - pose value text regeneration
  - render / measurement refresh

- Updated 3D drag synchronization
  - `SceneManager` now emits a `jointValueChanged` event
  - `main.js` bridges that event back into `JointControlsUI`
  - removed direct DOM-based slider syncing from the drag path

- Added new UI styles and i18n strings for both Chinese and English
- Added `yaml` as a dependency

## Behavior notes

- Pose input/output is always in radians
- Export only includes grouped pose values, not the joint name mapping
- Applied values follow the current joint limit UI behavior
- If values are clamped by the current limits, the exported pose values are immediately rewritten to the actual applied values

## Validation

- `npm run build`
