### PR TITLE
feat: support translation joints in joint controls with m/mm units and distinct color

### DIFF
--- a/index.html
+++ b/index.html
@@ -1972,6 +1972,27 @@
             border-color: rgba(0, 0, 0, 0.12);
         }
 
+        /* Translation joints: subtle amber accent (rotation joints keep default style) */
+        .joint-control--prismatic {
+            background: rgba(251, 191, 36, 0.08);
+            border-color: rgba(251, 191, 36, 0.25);
+        }
+
+        .joint-control--prismatic:hover {
+            background: rgba(251, 191, 36, 0.12);
+            border-color: rgba(251, 191, 36, 0.35);
+        }
+
+        [data-theme="light"] .joint-control--prismatic {
+            background: rgba(217, 119, 6, 0.08);
+            border-color: rgba(217, 119, 6, 0.25);
+        }
+
+        [data-theme="light"] .joint-control--prismatic:hover {
+            background: rgba(217, 119, 6, 0.12);
+            border-color: rgba(217, 119, 6, 0.35);
+        }
+
         .joint-header {
             display: flex;
             justify-content: space-between;

--- a/src/ui/JointControlsUI.js
+++ b/src/ui/JointControlsUI.js
@@ -22,6 +22,57 @@ export class JointControlsUI {
     }
 
     /**
+     * Whether the joint moves along an axis (translation) instead of rotating.
+     * URDF "prismatic" and MJCF "slide" joints are both normalized to 'prismatic'.
+     */
+    isTranslational(joint) {
+        return joint && joint.type === 'prismatic';
+    }
+
+    /**
+     * Display unit for a joint, depending on its type and the current unit toggle.
+     * Translation: m / mm. Rotation: rad / °.
+     */
+    getJointUnit(joint) {
+        if (this.isTranslational(joint)) {
+            return this.angleUnit === 'deg' ? 'mm' : 'm';
+        }
+        return this.angleUnit === 'deg' ? '°' : 'rad';
+    }
+
+    /**
+     * Number of decimals used when displaying a joint value.
+     */
+    getDisplayDecimals(joint) {
+        if (this.isTranslational(joint)) {
+            return this.angleUnit === 'deg' ? 1 : 3; // mm : m
+        }
+        return this.angleUnit === 'deg' ? 1 : 2; // ° : rad
+    }
+
+    /**
+     * Convert an internal joint value (radians for rotation, meters for
+     * translation) to the currently displayed unit.
+     */
+    toDisplayValue(joint, baseValue) {
+        if (this.isTranslational(joint)) {
+            return this.angleUnit === 'deg' ? baseValue * 1000 : baseValue; // m -> mm
+        }
+        return this.angleUnit === 'deg' ? baseValue * 180 / Math.PI : baseValue; // rad -> deg
+    }
+
+    /**
+     * Convert a value entered in the displayed unit back to the internal value
+     * (radians for rotation, meters for translation).
+     */
+    fromDisplayValue(joint, displayValue) {
+        if (this.isTranslational(joint)) {
+            return this.angleUnit === 'deg' ? displayValue / 1000 : displayValue; // mm -> m
+        }
+        return this.angleUnit === 'deg' ? displayValue * Math.PI / 180 : displayValue; // deg -> rad
+    }
+
+    /**
      * Update XML content in editor (URDF format only)
      */
     updateEditorXML(jointName, limits) {
@@ -143,6 +194,10 @@ export class JointControlsUI {
     createJointControl(joint, model) {
         const div = document.createElement('div');
         div.className = 'joint-control';
+        // Tint only translation joints differently; rotation joints keep the default style
+        if (this.isTranslational(joint)) {
+            div.classList.add('joint-control--prismatic');
+        }
 
         // First row: name + value
         const header = document.createElement('div');
@@ -202,26 +257,19 @@ export class JointControlsUI {
 
         const valueUnit = document.createElement('span');
         valueUnit.className = 'joint-value-unit';
-        valueUnit.textContent = this.angleUnit === 'deg' ? '°' : 'rad';
+        valueUnit.textContent = this.getJointUnit(joint);
 
         const updateLabels = () => {
             const currentMin = parseFloat(slider.min);
             const currentMax = parseFloat(slider.max);
-
-            if (this.angleUnit === 'deg') {
-                minLabel.value = (currentMin * 180 / Math.PI).toFixed(1);
-                maxLabel.value = (currentMax * 180 / Math.PI).toFixed(1);
-            } else {
-                minLabel.value = currentMin.toFixed(2);
-                maxLabel.value = currentMax.toFixed(2);
-            }
+            const decimals = this.getDisplayDecimals(joint);
+            minLabel.value = this.toDisplayValue(joint, currentMin).toFixed(decimals);
+            maxLabel.value = this.toDisplayValue(joint, currentMax).toFixed(decimals);
         };
 
         const updateValueInput = () => {
             const value = parseFloat(slider.value);
-            valueInput.value = this.angleUnit === 'deg' ?
-                (value * 180 / Math.PI).toFixed(1) :
-                value.toFixed(2);
+            valueInput.value = this.toDisplayValue(joint, value).toFixed(this.getDisplayDecimals(joint));
         };
 
         updateLabels();
@@ -235,9 +283,7 @@ export class JointControlsUI {
                 return;
             }
 
-            let valueInRad = this.angleUnit === 'deg' ?
-                inputValue * Math.PI / 180 :
-                inputValue;
+            let valueInRad = this.fromDisplayValue(joint, inputValue);
 
             const currentMax = parseFloat(slider.max);
             if (valueInRad >= currentMax) {
@@ -283,9 +329,7 @@ export class JointControlsUI {
                 return;
             }
 
-            let valueInRad = this.angleUnit === 'deg' ?
-                inputValue * Math.PI / 180 :
-                inputValue;
+            let valueInRad = this.fromDisplayValue(joint, inputValue);
 
             const currentMin = parseFloat(slider.min);
             if (valueInRad <= currentMin) {
@@ -505,9 +549,7 @@ export class JointControlsUI {
                 return;
             }
 
-            let valueInRad = this.angleUnit === 'deg' ?
-                inputValue * Math.PI / 180 :
-                inputValue;
+            let valueInRad = this.fromDisplayValue(joint, inputValue);
 
             const currentMin = parseFloat(slider.min);
             const currentMax = parseFloat(slider.max);
@@ -536,7 +578,7 @@ export class JointControlsUI {
         div._updateDisplay = () => {
             updateValueInput();
             updateLabels();
-            valueUnit.textContent = this.angleUnit === 'deg' ? '°' : 'rad';
+            valueUnit.textContent = this.getJointUnit(joint);
         };
 
         return div;


### PR DESCRIPTION
## Summary

The joint control panel previously assumed every joint was rotational — it always displayed values in `rad` / `°` and rendered every control box with the same style. Translation joints (URDF `prismatic`, MJCF `slide`) were therefore shown with incorrect units.

This PR adds proper handling for translation joints:

1. **Unit display & conversion** — translation joints now show their values, limits, and value input in **m / mm** (toggled by the existing unit switch) with correct conversion, instead of `rad` / `°`. Rotation joints are unchanged.
2. **Visual distinction** — translation joint control boxes use a distinct (amber) color so they are easy to tell apart from rotation joints. The layout/structure is identical to rotation joints — only the color differs.

## Changes

- `src/ui/JointControlsUI.js`
  - Added helpers `isTranslational`, `getJointUnit`, `getDisplayDecimals`, `toDisplayValue`, `fromDisplayValue` that branch on joint type (`joint.type === 'prismatic'`, covering both URDF prismatic and MJCF slide).
  - Internal values stay in base units (meters for translation, radians for rotation); display/parse converts to m/mm or rad/°.
  - Translation joints get a `joint-control--prismatic` class.
- `index.html`
  - Added `.joint-control--prismatic` styles (and a light-theme variant): same box style as rotation joints, only the background tint and border color differ.

## Unit conversion details

| Joint type  | Unit toggle = default | Unit toggle = alt | Decimals |
|-------------|-----------------------|-------------------|----------|
| Rotation    | `rad`                 | `°`               | 2 / 1    |
| Translation | `m`                   | `mm`              | 3 / 1    |

## Notes / out of scope

- When a prismatic joint has **no** limits defined, the existing fallback range is still `±π`, which is an odd `±3.14 m` default. URDF/MJCF translation joints normally specify limits, so this rarely triggers and was left unchanged.

## Test plan

- [ ] Load a model containing prismatic/slide joints — confirm those controls show `m`/`mm` and convert correctly when toggling units.
- [ ] Edit min/max limits and the value input for a translation joint — confirm the value applied to the model is correct.
- [ ] Confirm rotation joints still show `rad`/`°` and keep their original style.
- [ ] Toggle light/dark theme and confirm both joint types look correct.
